### PR TITLE
fix: remove unnecessary mentions from reply body

### DIFF
--- a/src/features/reply.ts
+++ b/src/features/reply.ts
@@ -34,9 +34,9 @@ export const renderReplyButtons = (): void => {
     );
 };
 
-const sanitizeBody = (body: string) => {
-  // Remove @ mentions from the string to avoid unnecessarily notifying people
-  return body.replace(/(?=\s*)@/, "");
+const sanitizeBody = (body: string): string => {
+  // Remove @ default mentions from the string to avoid unnecessarily notifying people
+  return body.replace(/(?=\s*)@/, "@.");
 };
 
 const renderReplyAllTrixMessage = (event: any): void => {

--- a/src/features/reply.ts
+++ b/src/features/reply.ts
@@ -56,7 +56,7 @@ const renderReplyAllTrixMessage = (event: any): void => {
   const firstMessage =
     tryBuildReplyBodyMessageFromLineBodyNodes(firstLineBodyNodes);
   const nextMessages = articles
-    .map((_, article) => {
+    .map((_: any, article: any) => {
       const lineBodyNode = $.parseHTML(
         $(article).find(".chat-line__body").html()
       );
@@ -64,11 +64,13 @@ const renderReplyAllTrixMessage = (event: any): void => {
       return tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNode);
     })
     .toArray()
-    .map((message) => `• ${message}`)
+    .map((message: string) => `• ${message}`)
     .join("<br>");
 
   const body = `• ${firstMessage} <br> ${nextMessages}`;
-  const reply = `<blockquote>${creatorName} - ${friendlyTimeMessage} <br> ${body}<br><br> > </blockquote>`;
+  // Remove @ mentions from the string to avoid unnecessarily notifying people
+  const sanitizedBody = body.replace(/(?:\s)+@(?=w+)|^@(?=w+)/, "");
+  const reply = `<blockquote>${creatorName} - ${friendlyTimeMessage} <br> ${sanitizedBody}<br><br> > </blockquote>`;
 
   $("trix-editor").html(reply);
 };

--- a/src/features/reply.ts
+++ b/src/features/reply.ts
@@ -36,7 +36,7 @@ export const renderReplyButtons = (): void => {
 
 const sanitizeBody = (body: string): string => {
   // Remove @ default mentions from the string to avoid unnecessarily notifying people
-  return body.replace(/(?=\s*)@/, "@.");
+  return body.replace(/(?=\s*)@/g, "@.");
 };
 
 const renderReplyAllTrixMessage = (event: any): void => {
@@ -69,7 +69,7 @@ const renderReplyAllTrixMessage = (event: any): void => {
       return tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNode);
     })
     .toArray()
-    .map((message: string) => `• ${message}`)
+    .map((message) => `• ${message}`)
     .join("<br>");
 
   const body = sanitizeBody(`• ${firstMessage} <br> ${nextMessages}`);
@@ -94,7 +94,9 @@ const renderReplyOnlyTrixMessage = (event: any): void => {
   const lineBodyNodes = $.parseHTML(
     $(turboFrame).find(".chat-line__body").html()
   );
-  const bodyMessage = sanitizeBody(tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNodes));
+  const bodyMessage = sanitizeBody(
+    tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNodes)
+  );
   const reply = `${creatorName} - ${friendlyTimeMessage} <br> • ${bodyMessage}<br><br> >`;
 
   $("trix-editor").html(reply);

--- a/src/features/reply.ts
+++ b/src/features/reply.ts
@@ -34,6 +34,11 @@ export const renderReplyButtons = (): void => {
     );
 };
 
+const sanitizeBody = (body: string) => {
+  // Remove @ mentions from the string to avoid unnecessarily notifying people
+  return body.replace(/(?=\s*)@/, "");
+};
+
 const renderReplyAllTrixMessage = (event: any): void => {
   const creatorName = $(event.currentTarget)
     .parent()
@@ -67,10 +72,8 @@ const renderReplyAllTrixMessage = (event: any): void => {
     .map((message: string) => `• ${message}`)
     .join("<br>");
 
-  const body = `• ${firstMessage} <br> ${nextMessages}`;
-  // Remove @ mentions from the string to avoid unnecessarily notifying people
-  const sanitizedBody = body.replace(/(?:\s)+@(?=w+)|^@(?=w+)/, "");
-  const reply = `<blockquote>${creatorName} - ${friendlyTimeMessage} <br> ${sanitizedBody}<br><br> > </blockquote>`;
+  const body = sanitizeBody(`• ${firstMessage} <br> ${nextMessages}`);
+  const reply = `<blockquote>${creatorName} - ${friendlyTimeMessage} <br> ${body}<br><br> > </blockquote>`;
 
   $("trix-editor").html(reply);
 };
@@ -89,7 +92,9 @@ const renderReplyOnlyTrixMessage = (event: any): void => {
   )} atrás`;
   const article = $(event.currentTarget).closest("article")[0];
   const lineBodyNodes = $.parseHTML($(article).find(".chat-line__body").html());
-  const bodyMessage = tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNodes);
+  const bodyMessage = sanitizeBody(
+    tryBuildReplyBodyMessageFromLineBodyNodes(lineBodyNodes)
+  );
   const reply = `<blockquote>${creatorName} - ${friendlyTimeMessage} <br> • ${bodyMessage}<br><br> > </blockquote>`;
 
   $("trix-editor").html(reply);


### PR DESCRIPTION
This PR aims to resolve an issue where messages containing mentions notify people (sometimes the wrong person) even if the mention is removed by the Basecamp interface afterwards