### PR TITLE
fix: Portuguese redundancy in time message

### DIFF
--- a/src/features/reply.ts
+++ b/src/features/reply.ts
@@ -48,7 +48,7 @@ const renderReplyAllTrixMessage = (event: any): void => {
     .parent()
     .find("time")
     .attr("datetime");
-  const friendlyTimeMessage = `há ${computeFriendlyDifferenceFromNow(
+  const friendlyTimeMessage = `${computeFriendlyDifferenceFromNow(
     articleCreatedAt
   )} atrás`;
   const creatorId = $(event.currentTarget).parent().attr("data-creator-id");
@@ -87,7 +87,7 @@ const renderReplyOnlyTrixMessage = (event: any): void => {
     .parent()
     .find("time")
     .attr("datetime");
-  const friendlyTimeMessage = `há ${computeFriendlyDifferenceFromNow(
+  const friendlyTimeMessage = `${computeFriendlyDifferenceFromNow(
     articleCreatedAt
   )} atrás`;
   const turboFrame = $(event.currentTarget).closest("turbo-frame")[0];


### PR DESCRIPTION
In Portuguese the expression "Há ... (time) atrás" is redundant.
The verb "to have" already indicates time, same meaning to time adverb "ago". It also happens in English language, we need to write usually "5 minutes ago" (e.g.).
To solve I decided to omit one of them.

I will provide some possible readings for reference:
['Há muito tempo atrás' é redundante; entenda mais sobre o verbo 'haver'](http://g1.globo.com/educacao/blog/dicas-de-portugues/post/duvidas-dos-leitores-80.html)
[É certo falar "há dias atrás"?](http://www.redacaonotadez.com.br/ha-dias-atras/)
[HÁ DIAS (ATRÁS) - Língua Brasil](https://www.linguabrasil.com.br/nao-tropece-detail.php?id=723)