### PR TITLE
chore: add seconds message

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -15,6 +15,8 @@ const computeFriendlyDifferenceByDate = (
 
   if (hours === 0) {
     const minutes = differenceInMinutes(startDate, finalDate);
+    if (minutes === 0) return "Alguns segundos"
+    
     message = minutes === 1 ? "minuto" : "minutos";
 
     return `${minutes} ${message}`;


### PR DESCRIPTION
[line-18-time]: https://github.com/lukascivil/basecamp-essentials/blob/master/src/utils/time.ts#L18
In [line 18][line-18-time] of `time.ts` file we have the minutes validation considering if minute is equal to 1 (one) or not, returning the minute word as singular or plural.
This validation becomes a problem when we think about 0 (zero), zero is not one, then returns "minutes" in the plural, we can see the problem right here:
![image](https://user-images.githubusercontent.com/50001206/148999074-e3826e53-ebcd-4291-a5d3-74d003d15941.png)

At the same time, it wouldn't be nice if the function returned "0 minute" (_0 minuto_ 🇧🇷 ), it's spelling correct, but it's not what we want.
So I added an if statement that already returns the message "A few seconds" so that later the phrase displayed is "A few seconds ago" (_Alguns segundos atrás_ 🇧🇷 ).
